### PR TITLE
feat: 인터셉터를 활용한 회원 인가 프로세스 구현

### DIFF
--- a/src/main/java/com/ssafy/nuri_trip/domain/user/controller/UserController.java
+++ b/src/main/java/com/ssafy/nuri_trip/domain/user/controller/UserController.java
@@ -4,13 +4,11 @@ import com.ssafy.nuri_trip.domain.user.dto.SignUpReq;
 import com.ssafy.nuri_trip.domain.user.service.UserService;
 import com.ssafy.nuri_trip.global.common.BaseException;
 import com.ssafy.nuri_trip.global.common.BaseResponse;
+import com.ssafy.nuri_trip.global.config.NoAuth;
 import com.ssafy.nuri_trip.global.controller.AbstractRestController;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/api/users")
@@ -20,6 +18,7 @@ public class UserController extends AbstractRestController {
     private final UserService service;
 
     @PostMapping("/signup")
+    @NoAuth
     public ResponseEntity<BaseResponse<?>> signup(@RequestBody SignUpReq signUpReq){
         try{
             service.register(signUpReq);
@@ -28,4 +27,12 @@ public class UserController extends AbstractRestController {
             return handleException(e.getStatus());
         }
     }
+
+    /**
+     * 유저 미션 관련 기능
+     */
+
+
+
+
 }

--- a/src/main/java/com/ssafy/nuri_trip/global/config/AuthenticationInterceptor.java
+++ b/src/main/java/com/ssafy/nuri_trip/global/config/AuthenticationInterceptor.java
@@ -1,0 +1,58 @@
+package com.ssafy.nuri_trip.global.config;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.ssafy.nuri_trip.domain.auth.dto.JwtDto;
+import com.ssafy.nuri_trip.global.common.BaseException;
+import com.ssafy.nuri_trip.global.utils.JwtService;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.method.HandlerMethod;
+import org.springframework.web.servlet.HandlerInterceptor;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@RequiredArgsConstructor
+public class AuthenticationInterceptor implements HandlerInterceptor {
+    private final JwtService jwtService;
+    private final ObjectMapper objectMapper;    //자바 객체를 json으로 serialization
+
+    @Override
+    public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) throws Exception{
+        boolean check = checkAnnotation(handler, NoAuth.class);
+        if(check) return true;
+        try{
+            if(request.getMethod().equals("OPTIONS")) {
+                return true;
+            }
+            JwtDto jwtDto = jwtService.getUserInfo();
+            Long userIdByJwt = jwtDto.getId();
+            request.setAttribute("userId", userIdByJwt);
+            System.out.println(userIdByJwt + ": 인증 성공");
+
+        } catch(BaseException exception){
+
+            response.setStatus(HttpServletResponse.SC_FORBIDDEN); // 403 Forbidden
+
+            String requestURI = request.getRequestURI();
+
+            Map<String, String> map = new HashMap<>();
+            //redirectURI는 로그인 후 다시 원래 페이지로 돌아가기 위함이다.
+            map.put("requestURI", "/auth/signin?redirectURI="+requestURI);
+            String json = objectMapper.writerWithDefaultPrettyPrinter().writeValueAsString(map);
+            response.getWriter().write(json);
+
+            return false;
+        }
+        return true;
+    }
+    private boolean checkAnnotation(Object handler, Class cls){
+        HandlerMethod handlerMethod = (HandlerMethod) handler;
+        if(handlerMethod.getMethodAnnotation(cls)!=null){   //해당 annotation이 존재하면 true
+            return true;
+        }
+        return false;
+    }
+
+}

--- a/src/main/java/com/ssafy/nuri_trip/global/config/NoAuth.java
+++ b/src/main/java/com/ssafy/nuri_trip/global/config/NoAuth.java
@@ -1,0 +1,11 @@
+package com.ssafy.nuri_trip.global.config;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME) //어노테이션 레벨을 결정짓는다.
+@Target({ElementType.TYPE, ElementType.METHOD})
+public @interface NoAuth {
+}

--- a/src/main/java/com/ssafy/nuri_trip/global/config/WebConfig.java
+++ b/src/main/java/com/ssafy/nuri_trip/global/config/WebConfig.java
@@ -1,0 +1,26 @@
+package com.ssafy.nuri_trip.global.config;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.ssafy.nuri_trip.global.utils.JwtService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.EnableWebMvc;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+@EnableWebMvc
+@RequiredArgsConstructor
+public class WebConfig implements WebMvcConfigurer {
+    private final JwtService jwtService;
+    private final ObjectMapper objectMapper;
+
+    @Override
+    public void addInterceptors(InterceptorRegistry reg){
+        reg.addInterceptor(new AuthenticationInterceptor(jwtService, objectMapper))
+                .order(1)
+                .addPathPatterns("/**")    //interceptor 작업이 필요한 path 모두 추가
+                .excludePathPatterns("/auth/**");
+    }
+
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

> #2 

## 📝작업 내용

> 인터셉터를 활용한 회원 인가 프로세스 구현
- jwt가 유효하지 않거나 존재하지 않으면 로그인을 다시 수행해야 하므로 로그인 api로 넘겨주고, 추후 인증 이후에 다시 해당 페이지로 돌아올 수 있도록 redirect_uri를 추가했습니다.
- 따로 인가가 필요하지 않은 api 메소드 위에 어노테이션 형식으로 추가하기 위해 커스텀 어노테이션으로 NoAuth를 생성하였습니다. 
- NoAuth 어노테이션이 있는 api는 바로 true를 리턴하여 메소드를 실행할 수 있도록 하였습니다.